### PR TITLE
:zap: Beef up cloud run and DB resources

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+# https://docs.blockscout.com/for-developers/information-and-settings/env-variables
 # https://github.com/blockscout/blockscout/blob/v4.1.8-beta/docker-compose/envs/common-blockscout.env
 # DOCKER_TAG=
 ETHEREUM_JSONRPC_VARIANT=geth

--- a/terraform/databases.tf
+++ b/terraform/databases.tf
@@ -20,7 +20,7 @@ resource "google_sql_database_instance" "default" {
   region           = var.region
 
   settings {
-    tier = "db-g1-small"
+    tier = "db-custom-2-4096"
 
     database_flags {
       name  = "max_connections"


### PR DESCRIPTION
Up the CPU from default of 1vCPU to 4vCPU and from 512Mi to 8192Mi. We were way under provisionned jugging by the cloud metrics and doc: https://docs.blockscout.com/for-projects/resource-requirements
Database goes from `db-g1-small` (1.7GB of ram and shared vCPU) to `db-custom-2-4096`.

Increase the `startup_probe.initial_delay_seconds` from default 0 to 60 so the service has time to run the migration script before starting. This may still require some adjustment and cold start improvements.

Update the JSON RPC URL to point to the Canto Nginx Cloud Run URL until we get the domain name and certificate sorted out.