### PR TITLE
:bricks: Load balancer setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,15 @@ devops/terraform/plan: devops/terraform/select/$(WORKSPACE)
 
 devops/terraform/apply: devops/terraform/select/$(WORKSPACE)
 	terraform -chdir=terraform apply -auto-approve
+
+devops/terraform/output: devops/terraform/select/$(WORKSPACE)
+	terraform -chdir=terraform output
+
+devops/terraform/redeploy: devops/terraform/select/$(WORKSPACE)
+	terraform -chdir=terraform destroy -target=google_cloud_run_service.default -auto-approve
+	make devops/terraform/apply
+
+# https://github.com/terraform-google-modules/terraform-google-lb-http/blob/v6.3.0/docs/upgrading-v2.0.0-v3.0.0.md#dealing-with-dependencies
+devops/terraform/destroy/serverless_neg: devops/terraform/select/$(WORKSPACE)
+	terraform -chdir=terraform destroy \
+	-target=google_compute_region_network_endpoint_group.serverless_neg -auto-approve

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Canto Explorer Infra
 
-<https://blockscout-run-service-dev-3mid33wd4a-uc.a.run.app/>
+<https://testnet-canto-explorer.ansybl.io>
 
 Automates the [BlockScout](https://github.com/blockscout/blockscout) deployment to Goole Cloud Platform for Canto.
 

--- a/terraform/addresses.tf
+++ b/terraform/addresses.tf
@@ -1,0 +1,4 @@
+resource "google_compute_global_address" "load_balancer_address" {
+  name       = "${local.service_name}-load-balancer-address-${local.environment}"
+  ip_version = "IPV4"
+}

--- a/terraform/load_balancer.tf
+++ b/terraform/load_balancer.tf
@@ -1,0 +1,46 @@
+resource "google_compute_region_network_endpoint_group" "this" {
+  count                 = var.create_load_balancer ? 1 : 0
+  project               = var.project
+  name                  = "${local.service_name}-neg-${local.environment}"
+  network_endpoint_type = "SERVERLESS"
+  region                = var.region
+  cloud_run {
+    service = google_cloud_run_service.default.name
+  }
+}
+
+module "load_balancer" {
+  count          = var.create_load_balancer ? 1 : 0
+  source         = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
+  version        = "6.3.0"
+  project        = var.project
+  name           = "${local.service_name}-load-balancer-${local.environment}"
+  create_address = false
+  address        = google_compute_global_address.load_balancer_address.address
+
+  backends = {
+    default = {
+      description = null
+      groups = [
+        {
+          group = google_compute_region_network_endpoint_group.this[0].id
+        }
+      ]
+      enable_cdn              = false
+      security_policy         = null
+      custom_request_headers  = null
+      custom_response_headers = null
+
+      iap_config = {
+        enable               = false
+        oauth2_client_id     = null
+        oauth2_client_secret = null
+      }
+
+      log_config = {
+        enable      = true
+        sample_rate = 0.01
+      }
+    }
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -74,7 +74,7 @@ resource "google_cloud_run_service" "default" {
         }
         env {
           name  = "ETHEREUM_JSONRPC_HTTP_URL"
-          value = "https://canto-validator-nginx-reverse-proxy-node1-testnet-3mid33wd4a-uc.a.run.app/evm_rpc/"
+          value = "https://canto-node1.ansybl.io/evm_rpc/"
         }
         env {
           # as in november 2022, the blockscout database URL parser crashes when using the unix socket url syntax
@@ -101,7 +101,7 @@ resource "google_cloud_run_service" "default" {
         }
         env {
           name  = "ETHEREUM_JSONRPC_TRACE_URL"
-          value = "https://canto-validator-nginx-reverse-proxy-node1-testnet-3mid33wd4a-uc.a.run.app/evm_rpc/"
+          value = "https://canto-node1.ansybl.io/evm_rpc/"
         }
         env {
           name  = "NETWORK"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,7 @@
+output "load_balancer_ip" {
+  value = module.load_balancer[0].external_ip
+}
+
+output "nginx_reverse_proxy_url" {
+  value = google_cloud_run_service.default.status.0.url
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -6,4 +6,5 @@ project = "dfpl-playground"
 region  = "us-central1"
 zone    = "us-central1-a"
 
+create_load_balancer = true
 prefix = "canto-explorer"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -37,6 +37,11 @@ variable "db_password" {
   default = ""
 }
 
+variable "create_load_balancer" {
+  type    = bool
+  default = false
+}
+
 locals {
   environment  = terraform.workspace
   service_name = "blockscout"


### PR DESCRIPTION
Cloud Run doesn't seem to support mapping domains from CloudFlare CNAME. Introduce a load balancer for more flexibility.
On the CloudFlare side we can simply point a A DNS type to the LB IP. Note this setup is optional and disabled by default, but can be enabled via the `create_load_balancer` variable.

On the Cloudflare side, we map the testnet-canto-explorer.ansybl.io domain to the load balancer IP.