### PR TITLE
:recycle: Drop load balancer and leverage domain mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,8 +71,11 @@ devops/terraform/output: devops/terraform/select/$(WORKSPACE)
 	terraform -chdir=terraform output
 
 devops/terraform/redeploy: devops/terraform/select/$(WORKSPACE)
-	terraform -chdir=terraform destroy -target=google_cloud_run_service.default -auto-approve
-	make devops/terraform/apply
+	terraform -chdir=terraform apply \
+	-replace=google_cloud_run_service.default \
+	-target=google_cloud_run_service.default \
+	-target=google_cloud_run_service_iam_policy.noauth \
+	-target=google_cloud_run_domain_mapping.default
 
 # https://github.com/terraform-google-modules/terraform-google-lb-http/blob/v6.3.0/docs/upgrading-v2.0.0-v3.0.0.md#dealing-with-dependencies
 devops/terraform/destroy/serverless_neg: devops/terraform/select/$(WORKSPACE)

--- a/terraform/cloudflare.tf
+++ b/terraform/cloudflare.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "cloudflare" {
+  api_token = data.google_secret_manager_secret_version.cloudflare_api_token.secret_data
+}
+
+resource "cloudflare_record" "this" {
+  count   = var.create_cloudflare ? 1 : 0
+  name    = var.domain_prefix
+  zone_id = var.cloudflare_zone_id
+  value   = "ghs.googlehosted.com"
+  type    = "CNAME"
+  proxied = true
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -494,6 +494,9 @@ resource "google_cloud_run_service" "default" {
       }
 
       labels = {
+        # make that change explicit or Terraform keeps thinking we want to change to null
+        "run.googleapis.com/startupProbeType" = "Custom"
+
         environment  = local.environment
         service_name = local.service_name
         prefix       = var.prefix
@@ -527,4 +530,17 @@ resource "google_cloud_run_service_iam_policy" "noauth" {
   service  = google_cloud_run_service.default.name
 
   policy_data = data.google_iam_policy.noauth.policy_data
+}
+
+resource "google_cloud_run_domain_mapping" "default" {
+  location = var.region
+  name     = local.domain_name
+
+  metadata {
+    namespace = var.project
+  }
+
+  spec {
+    route_name = google_cloud_run_service.default.name
+  }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,5 +1,5 @@
 output "load_balancer_ip" {
-  value = module.load_balancer[0].external_ip
+  value = var.create_load_balancer ? module.load_balancer[0].external_ip : null
 }
 
 output "nginx_reverse_proxy_url" {

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -1,0 +1,12 @@
+resource "google_project_service" "secretmanager" {
+  provider           = google
+  service            = "secretmanager.googleapis.com"
+  disable_on_destroy = false
+}
+
+# generated from https://dash.cloudflare.com/profile/api-tokens
+data "google_secret_manager_secret_version" "cloudflare_api_token" {
+  secret     = "${var.prefix}-cloudflare-api-token-${local.environment}"
+  version    = "latest"
+  depends_on = [google_project_service.secretmanager]
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -6,7 +6,12 @@ project = "dfpl-playground"
 region  = "us-central1"
 zone    = "us-central1-a"
 
-create_load_balancer = true
-prefix               = "canto-explorer"
+prefix = "canto-explorer"
 
-ethereum_jsonrpc_http_url = "https://canto-testnet.ansybl.io/evm_rpc/"
+ethereum_jsonrpc_http_url = "https://canto-testnet.plexnode.wtf"
+
+# Cloudflare
+create_cloudflare  = true
+cloudflare_zone_id = "d04d29e748329c8dabf1aac878a373ce"
+domain_prefix      = "canto-evm-testnet"
+domain_suffix      = "ansybl.io"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -46,8 +46,30 @@ variable "ethereum_jsonrpc_http_url" {
   type = string
 }
 
+variable "create_cloudflare" {
+  type    = bool
+  default = false
+}
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "The zone identifier"
+  default     = ""
+}
+
+variable "domain_prefix" {
+  type    = string
+  default = ""
+}
+
+variable "domain_suffix" {
+  type    = string
+  default = ""
+}
+
 locals {
   environment  = terraform.workspace
   service_name = "blockscout"
   image_name   = "${local.service_name}-${local.environment}"
+  domain_name  = "${var.domain_prefix}.${var.domain_suffix}"
 }


### PR DESCRIPTION
This makes the setup easier as we can drop load balancer resources, but also cheaper as we drop the load balancer and static IP reservation.
Also update the RPC URL to consume a Plex node